### PR TITLE
Criando função de criação de arquivo `.lst`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ compile_commands.json
 *.ini
 *.exe
 *.obj
-*.lsm
+*.lst
 subprojects/glfw-*
 subprojects/imgui-*
 subprojects/packagecache

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ compile_commands.json
 *.ini
 *.exe
 *.obj
+*.lsm
 subprojects/glfw-*
 subprojects/imgui-*
 subprojects/packagecache

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -97,11 +97,11 @@ void Assembler::WriteListingFile() {
   }
 
   lstFile << "\nLISTAGEM DE CÓDIGO\n";
-  for (const auto &entry : this->listingLines) {
-    lstFile << "[" << std::setw(4) << std::setfill('0') << entry.address << " "
+  for (const auto &line : this->listingLines) {
+    lstFile << "[" << std::setw(4) << std::setfill('0') << line.address << " "
             << std::setw(5) << std::setfill('0')
-            << std::stoi(entry.generatedCode) << "] " << std::setw(3)
-            << std::setfill('0') << entry.lineNumber << " " << entry.sourceCode
+            << std::stoi(line.generatedCode) << "] " << std::setw(3)
+            << std::setfill('0') << line.lineNumber << " " << line.sourceCode
             << "\n";
   }
 

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -99,9 +99,8 @@ void Assembler::WriteListingFile() {
   lstFile << "\nLISTAGEM DE CÓDIGO\n";
   for (const auto &line : this->listingLines) {
     lstFile << "[" << std::setw(5) << std::setfill('0') << line.address << " - "
-            << std::stoi(line.generatedCode) << "] " << std::setw(3)
-            << std::setfill('0') << line.lineNumber << " - " << line.sourceCode
-            << "\n";
+            << line.generatedCode << "] " << std::setw(3) << std::setfill('0')
+            << line.lineNumber << " - " << line.sourceCode << "\n";
   }
 
   if (!this->listingErrors.empty()) {

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -96,24 +96,20 @@ void Assembler::WriteListingFile() {
     return;
   }
 
-  for (const ListingLine &entry : this->listingLines) {
-    char addressStr[5], codeStr[6], lineStr[4];
-
-    // Padding para manter length dos campos
-    snprintf(addressStr, sizeof(addressStr), "%04d", entry.address);
-    snprintf(codeStr, sizeof(codeStr), "%05d", std::stoi(entry.generatedCode));
-    snprintf(lineStr, sizeof(lineStr), "%03d", entry.lineNumber);
-
-    lstFile << "[" << addressStr << " " << codeStr << "] " << lineStr << " "
-            << entry.sourceCode << "\n";
+  lstFile << "\nLISTAGEM DE CÓDIGO\n";
+  for (const auto &entry : this->listingLines) {
+    lstFile << "[" << std::setw(4) << std::setfill('0') << entry.address << " "
+            << std::setw(5) << std::setfill('0')
+            << std::stoi(entry.generatedCode) << "] " << std::setw(3)
+            << std::setfill('0') << entry.lineNumber << " " << entry.sourceCode
+            << "\n";
   }
 
   if (!this->listingErrors.empty()) {
     lstFile << "\nERROS DE COMPILAÇÃO\n";
     for (const ListingError &err : this->listingErrors) {
-      char lineStr[4];
-      snprintf(lineStr, sizeof(lineStr), "%03d", err.lineNumber);
-      lstFile << "Linha " << lineStr << ": " << err.error << "\n";
+      lstFile << "Linha " << std::setw(3) << std::setfill('0') << err.lineNumber
+              << ": " << err.error << "\n";
     }
   } else {
     lstFile << "\nNENHUM ERRO DETECTADO\n";

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -110,7 +110,7 @@ void Assembler::WriteListingFile() {
 
   if (!this->listingErrors.empty()) {
     lstFile << "\nERROS DE COMPILAÇÃO\n";
-    for (const auto &err : this->listingErrors) {
+    for (const ListingError &err : this->listingErrors) {
       char lineStr[4];
       snprintf(lineStr, sizeof(lineStr), "%03d", err.lineNumber);
       lstFile << "Linha " << lineStr << ": " << err.error << "\n";

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -98,10 +98,9 @@ void Assembler::WriteListingFile() {
 
   lstFile << "\nLISTAGEM DE CÓDIGO\n";
   for (const auto &line : this->listingLines) {
-    lstFile << "[" << std::setw(4) << std::setfill('0') << line.address << " "
-            << std::setw(5) << std::setfill('0')
+    lstFile << "[" << std::setw(5) << std::setfill('0') << line.address << " - "
             << std::stoi(line.generatedCode) << "] " << std::setw(3)
-            << std::setfill('0') << line.lineNumber << " " << line.sourceCode
+            << std::setfill('0') << line.lineNumber << " - " << line.sourceCode
             << "\n";
   }
 

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -88,4 +88,36 @@ void Assembler::WriteObjectCodeFile() {
 }
 
 // escreve o arquivo .lst com this->listingLines e this->listingErrors
-void Assembler::WriteListingFile() {}
+void Assembler::WriteListingFile() {
+  std::ofstream lstFile(this->lstFilePath);
+  if (!lstFile) {
+    std::cerr << "Erro ao abrir o arquivo de listagem: " << this->lstFilePath
+              << std::endl;
+    return;
+  }
+
+  for (const ListingLine &entry : this->listingLines) {
+    char addressStr[5], codeStr[6], lineStr[4];
+
+    // Padding para manter length dos campos
+    snprintf(addressStr, sizeof(addressStr), "%04d", entry.address);
+    snprintf(codeStr, sizeof(codeStr), "%05d", std::stoi(entry.generatedCode));
+    snprintf(lineStr, sizeof(lineStr), "%03d", entry.lineNumber);
+
+    lstFile << "[" << addressStr << " " << codeStr << "] " << lineStr << " "
+            << entry.sourceCode << "\n";
+  }
+
+  if (!this->listingErrors.empty()) {
+    lstFile << "\nERROS DE COMPILAÇÃO\n";
+    for (const auto &err : this->listingErrors) {
+      char lineStr[4];
+      snprintf(lineStr, sizeof(lineStr), "%03d", err.lineNumber);
+      lstFile << "Linha " << lineStr << ": " << err.error << "\n";
+    }
+  } else {
+    lstFile << "\nNENHUM ERRO DETECTADO\n";
+  }
+
+  lstFile.close();
+}

--- a/src/assembler.hpp
+++ b/src/assembler.hpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
# Criando função de criação de arquivo `.lst`
A função supoem que os vetores `listingLines` e `listingErrors` foram preenchidos pela primeira passada;
Biblioteca `iomanip` utilizada para padding de string (para os campos terem o mesmo tamanho sempre).
Exemplo de output:

Resolves: #20 

```
LISTAGEM DE CÓDIGO
[00000 - 10 34] 001 - LOAD 5
[00001 - 20 45] 002 - ADD B
[00002 - 13 20 50] 003 - COPY A B
[00003 - 4 12] 004 - JMP LOOP
[00004 - 0] 005 - LOOP: NOP

ERROS DE COMPILAÇÃO
Linha 006: Símbolo indefinido: END_LOOP
Linha 002: Registrador inválido: C
```